### PR TITLE
Use --logging, --monitoring flags

### DIFF
--- a/components/google-cloud-support/google-cloud-support.sh
+++ b/components/google-cloud-support/google-cloud-support.sh
@@ -34,7 +34,7 @@ function gcp_create_k8s_cluster() {
       --metadata disable-legacy-endpoints=true \
       --scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" \
       --num-nodes "5" \
-      --enable-stackdriver-kubernetes --enable-ip-alias \
+      --logging=SYSTEM,WORKLOAD --monitoring=SYSTEM --enable-ip-alias \
       --network "projects/${GCP_PROJECT_NAME}/global/networks/default" \
       --subnetwork "projects/${GCP_PROJECT_NAME}/regions/us-central1/subnetworks/default" \
       --default-max-pods-per-node "110" \


### PR DESCRIPTION
--enable-stackdriver-kubernetes has been deprecated: https://cloud.google.com/stackdriver/docs/solutions/gke/installing